### PR TITLE
Improvements to the Proclone/Router Startup

### DIFF
--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -212,7 +212,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			})
 			cloningUPIDs = append(cloningUPIDs, proxmox.CloningTask{
 				UPID:       upid,
-				Node:       bestNode,
+				Node:       router.Node,
 			})
 		}
 
@@ -231,7 +231,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			}
 			cloningUPIDs = append(cloningUPIDs, proxmox.CloningTask{
 				UPID:       upid,
-				Node:       bestNode,
+				Node:       vm.Node,
 			})
 		}
 	}

--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -173,7 +173,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 		},
 	)
 
-	cloningUPIDs := []cloningTask{}
+	cloningUPIDs := []proxmox.CloningTask{}
 
 	for _, target := range req.Targets {
 		// Find best node per target
@@ -191,7 +191,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			NewVMID:    target.VMIDs[0],
 			TargetNode: bestNode,
 		}
-		upid, err = cs.ProxmoxService.cloneVMWithUPID(routerCloneReq)
+		upid, err = s.cloneVMWithUPID(routerCloneReq)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to clone router VM for %s: %v", target.Name, err))
 		} else {
@@ -210,7 +210,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 				VMID:       target.VMIDs[0],
 				PoolName:   target.PoolName,
 			})
-			cloningUPIDs = append(cloningUPIDs, cloningTask{
+			cloningUPIDs = append(cloningUPIDs, proxmox.CloningTask{
 				UPID:       upid,
 				Node:       bestNode,
 			})
@@ -225,11 +225,11 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 				NewVMID:    target.VMIDs[i+1],
 				TargetNode: bestNode,
 			}
-			upid, err = cs.ProxmoxService.cloneVMWithUPID(vmCloneReq)
+			upid, err = s.cloneVMWithUPID(vmCloneReq)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("failed to clone VM %s for %s: %v", vm.Name, target.Name, err))
 			}
-			cloningUPIDs = append(cloningUPIDs, cloningTask{
+			cloningUPIDs = append(cloningUPIDs, proxmox.CloningTask{
 				UPID:       upid,
 				Node:       bestNode,
 			})

--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -202,6 +202,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			// Store router info for later operations
 			clonedRouters = append(clonedRouters, RouterInfo{
 				TargetName: target.Name,
+				PoolName:   target.PoolName,
 				RouterType: routerType,
 				PodNumber:  target.PodNumber,
 				Node:       bestNode,
@@ -344,7 +345,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 		}
 
 		log.Printf("Configuring pod router for %s (Pod: %d, VMID: %d)", routerInfo.TargetName, routerInfo.PodNumber, routerInfo.VMID)
-		err = cs.ProxmoxService.ConfigurePodRouter(routerInfo.PodNumber, routerInfo.Node, routerInfo.VMID, routerInfo.RouterType)
+		err = cs.ProxmoxService.ConfigurePodRouter(routerInfo.PodNumber, routerInfo.Node, routerInfo.VMID, routerInfo.RouterType, routerInfo.PoolName)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to configure pod router for %s: %v", routerInfo.TargetName, err))
 		}

--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -206,6 +206,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 				PodNumber:  target.PodNumber,
 				Node:       bestNode,
 				VMID:       target.VMIDs[0],
+				PoolName:   target.PoolName,
 			})
 		}
 
@@ -344,7 +345,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 		}
 
 		log.Printf("Configuring pod router for %s (Pod: %d, VMID: %d)", routerInfo.TargetName, routerInfo.PodNumber, routerInfo.VMID)
-		err = cs.ProxmoxService.ConfigurePodRouter(routerInfo.PodNumber, routerInfo.Node, routerInfo.VMID, routerInfo.RouterType)
+		err = cs.ProxmoxService.ConfigurePodRouter(routerInfo.PodNumber, routerInfo.Node, routerInfo.VMID, routerInfo.RouterType, routerInfo.PoolName)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to configure pod router for %s: %v", routerInfo.TargetName, err))
 		}

--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -191,7 +191,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			NewVMID:    target.VMIDs[0],
 			TargetNode: bestNode,
 		}
-		upid, err = s.cloneVMWithUPID(routerCloneReq)
+		upid, err := cs.ProxmoxService.CloneVMWithUPID(routerCloneReq)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to clone router VM for %s: %v", target.Name, err))
 		} else {
@@ -225,7 +225,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 				NewVMID:    target.VMIDs[i+1],
 				TargetNode: bestNode,
 			}
-			upid, err = s.cloneVMWithUPID(vmCloneReq)
+			upid, err := cs.ProxmoxService.CloneVMWithUPID(vmCloneReq)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("failed to clone VM %s for %s: %v", vm.Name, target.Name, err))
 			}

--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -173,7 +173,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 		},
 	)
 
-	cloningUPIDs := []cloningTask
+	cloningUPIDs := []cloningTask{}
 
 	for _, target := range req.Targets {
 		// Find best node per target
@@ -212,7 +212,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			})
 			cloningUPIDs = append(cloningUPIDs, cloningTask{
 				UPID:       upid,
-				Node        bestNode,
+				Node:       bestNode,
 			})
 		}
 

--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -202,7 +202,6 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			// Store router info for later operations
 			clonedRouters = append(clonedRouters, RouterInfo{
 				TargetName: target.Name,
-				PoolName:   target.PoolName,
 				RouterType: routerType,
 				PodNumber:  target.PodNumber,
 				Node:       bestNode,
@@ -345,7 +344,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 		}
 
 		log.Printf("Configuring pod router for %s (Pod: %d, VMID: %d)", routerInfo.TargetName, routerInfo.PodNumber, routerInfo.VMID)
-		err = cs.ProxmoxService.ConfigurePodRouter(routerInfo.PodNumber, routerInfo.Node, routerInfo.VMID, routerInfo.RouterType, routerInfo.PoolName)
+		err = cs.ProxmoxService.ConfigurePodRouter(routerInfo.PodNumber, routerInfo.Node, routerInfo.VMID, routerInfo.RouterType)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to configure pod router for %s: %v", routerInfo.TargetName, err))
 		}

--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -173,6 +173,8 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 		},
 	)
 
+	cloningUPIDs := []cloningTask
+
 	for _, target := range req.Targets {
 		// Find best node per target
 		bestNode, err := cs.ProxmoxService.FindBestNode()
@@ -189,7 +191,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			NewVMID:    target.VMIDs[0],
 			TargetNode: bestNode,
 		}
-		err = cs.ProxmoxService.CloneVM(routerCloneReq)
+		upid, err = cs.ProxmoxService.cloneVMWithUPID(routerCloneReq)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("failed to clone router VM for %s: %v", target.Name, err))
 		} else {
@@ -208,6 +210,10 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 				VMID:       target.VMIDs[0],
 				PoolName:   target.PoolName,
 			})
+			cloningUPIDs = append(cloningUPIDs, cloningTask{
+				UPID:       upid,
+				Node        bestNode,
+			})
 		}
 
 		// Clone each VM to new pool
@@ -219,10 +225,14 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 				NewVMID:    target.VMIDs[i+1],
 				TargetNode: bestNode,
 			}
-			err := cs.ProxmoxService.CloneVM(vmCloneReq)
+			upid, err = cs.ProxmoxService.cloneVMWithUPID(vmCloneReq)
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("failed to clone VM %s for %s: %v", vm.Name, target.Name, err))
 			}
+			cloningUPIDs = append(cloningUPIDs, cloningTask{
+				UPID:       upid,
+				Node:       bestNode,
+			})
 		}
 	}
 
@@ -250,18 +260,14 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 			time.Sleep(2 * time.Second)
 		}
 
-		// Wait for all VM locks to be released
-		log.Printf("Waiting for all VM clone operations to complete for pool %s (checking locks)", target.PoolName)
-		poolVMs, err := cs.ProxmoxService.GetPoolVMs(target.PoolName)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("failed to get pool VMs after waiting for %s: %v", target.Name, err))
-			continue
-		}
+		// Wait for all VM cloning tasks to be completed
+		log.Printf("Waiting for all VM clone operations to complete for pool %s (checking tasks)", target.PoolName)
 
-		for _, vm := range poolVMs {
-			log.Printf("Waiting for VM %d (%s) lock to be released", vm.VmId, vm.Name)
-			if err := cs.ProxmoxService.WaitForLock(vm.NodeName, vm.VmId); err != nil {
-				log.Printf("Warning: timeout waiting for VM %d lock, continuing anyway: %v", vm.VmId, err)
+		// Stop long running clones before releasing mutex
+		for _, cloningUPID := range cloningUPIDs {
+			log.Printf("Waiting for clone task %s to finish on node %s", cloningUPID.UPID, cloningUPID.Node)
+			if err := cs.ProxmoxService.WaitForCloneTask(cloningUPID.Node, cloningUPID.UPID); err != nil {
+				log.Printf("Warning: timeout waiting for clone task %s, Error: %v", cloningUPID.UPID, err)
 			}
 		}
 

--- a/internal/cloning/types.go
+++ b/internal/cloning/types.go
@@ -119,6 +119,7 @@ type CloneRequest struct {
 
 type RouterInfo struct {
 	TargetName string
+	PoolName   string
 	RouterType string
 	PodNumber  int
 	Node       string

--- a/internal/cloning/types.go
+++ b/internal/cloning/types.go
@@ -123,6 +123,7 @@ type RouterInfo struct {
 	PodNumber  int
 	Node       string
 	VMID       int
+	PoolName   string
 }
 
 type ProgressMessage struct {

--- a/internal/cloning/types.go
+++ b/internal/cloning/types.go
@@ -119,7 +119,6 @@ type CloneRequest struct {
 
 type RouterInfo struct {
 	TargetName string
-	PoolName   string
 	RouterType string
 	PodNumber  int
 	Node       string

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -140,10 +140,9 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 	case "vyos":
 		reqBody := map[string]any{
 			"command": []string{
-				config.VYOSScriptPath,
-				fmt.Sprintf("%d", podNumber),
-				config.WANIPBase,
-				poolName,
+				"sh",
+				"-c",
+				fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g;s/{{POOL_NAME}}/%s/g' %s", podNumber, config.WANIPBase, poolName, config.VYOSScriptPath),
 			},
 		}
 
@@ -154,7 +153,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 		}
 
 		if err := s.agentExecWithRetry(execReq); err != nil {
-			return fmt.Errorf("failed to run VyOS setup script: %v", err)
+			return fmt.Errorf("failed to configure VyOS postconfig script: %v", err)
 		}
 
 	default:

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -40,7 +40,7 @@ func (s *ProxmoxService) GetRouterType(router VM) (string, error) {
 }
 
 // ConfigurePodRouter configures the pod router with proper networking settings
-func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, poolName string) error {
+func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string) error {
 	config := RouterConfig{
 		WANScriptPath:  s.Config.WANScriptPath,
 		VIPScriptPath:  s.Config.VIPScriptPath,
@@ -115,10 +115,9 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 	case "vyos":
 		reqBody := map[string]any{
 			"command": []string{
-				config.VYOSScriptPath,
-				fmt.Sprintf("%d", podNumber),
-				config.WANIPBase,
-				poolName,
+				"sh",
+				"-c",
+				fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g' %s", podNumber, config.WANIPBase, config.VYOSScriptPath),
 			},
 		}
 
@@ -130,7 +129,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 
 		_, err := s.RequestHelper.MakeRequest(execReq)
 		if err != nil {
-			return fmt.Errorf("failed to run VyOS setup script: %v", err)
+			return fmt.Errorf("failed to make IP change request: %v", err)
 		}
 
 	default:

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -40,7 +40,7 @@ func (s *ProxmoxService) GetRouterType(router VM) (string, error) {
 }
 
 // ConfigurePodRouter configures the pod router with proper networking settings
-func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string) error {
+func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, poolName string) error {
 	config := RouterConfig{
 		WANScriptPath:  s.Config.WANScriptPath,
 		VIPScriptPath:  s.Config.VIPScriptPath,
@@ -115,9 +115,10 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 	case "vyos":
 		reqBody := map[string]any{
 			"command": []string{
-				"sh",
-				"-c",
-				fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g' %s", podNumber, config.WANIPBase, config.VYOSScriptPath),
+				config.VYOSScriptPath,
+				fmt.Sprintf("%d", podNumber),
+				config.WANIPBase,
+				poolName,
 			},
 		}
 
@@ -129,7 +130,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 
 		_, err := s.RequestHelper.MakeRequest(execReq)
 		if err != nil {
-			return fmt.Errorf("failed to make IP change request: %v", err)
+			return fmt.Errorf("failed to run VyOS setup script: %v", err)
 		}
 
 	default:

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -140,9 +140,10 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 	case "vyos":
 		reqBody := map[string]any{
 			"command": []string{
-				"sh",
-				"-c",
-				fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g;s/{{POOL_NAME}}/%s/g' %s", podNumber, config.WANIPBase, poolName, config.VYOSScriptPath),
+				config.VYOSScriptPath,
+				fmt.Sprintf("%d", podNumber),
+				config.WANIPBase,
+				poolName,
 			},
 		}
 
@@ -153,7 +154,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 		}
 
 		if err := s.agentExecWithRetry(execReq); err != nil {
-			return fmt.Errorf("failed to configure VyOS postconfig script: %v", err)
+			return fmt.Errorf("failed to run VyOS setup script: %v", err)
 		}
 
 	default:

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -18,7 +18,7 @@ type agentExecResult struct {
 
 // agentExecStatus holds the response from agent/exec-status
 type agentExecStatus struct {
-	Exited   bool   `json:"exited"`
+	Exited   int    `json:"exited"`
 	ExitCode int    `json:"exitcode"`
 	OutData  string `json:"out-data"`
 	ErrData  string `json:"err-data"`
@@ -74,7 +74,7 @@ func (s *ProxmoxService) execAgentCommand(node string, vmid int, command []strin
 			return fmt.Errorf("failed to parse agent exec-status response: %v", err)
 		}
 
-		if !status.Exited {
+		if status.Exited == 0 {
 			time.Sleep(2 * time.Second)
 			continue
 		}

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -39,33 +39,6 @@ func (s *ProxmoxService) GetRouterType(router VM) (string, error) {
 	}
 }
 
-// agentExecWithRetry retries an agent/exec request with exponential backoff.
-// The QEMU guest agent may respond to pings before it's fully ready to handle
-// exec commands (Proxmox returns status 596 in that case).
-func (s *ProxmoxService) agentExecWithRetry(execReq tools.ProxmoxAPIRequest) error {
-	backoff := 2 * time.Second
-	maxBackoff := 15 * time.Second
-	maxRetries := 10
-
-	var lastErr error
-	for attempt := range maxRetries {
-		_, lastErr = s.RequestHelper.MakeRequest(execReq)
-		if lastErr == nil {
-			return nil
-		}
-
-		if !strings.Contains(lastErr.Error(), "status 596") {
-			return lastErr // Non-retryable error
-		}
-
-		log.Printf("agent/exec attempt %d/%d failed with status 596, retrying in %v", attempt+1, maxRetries, backoff)
-		time.Sleep(backoff)
-		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
-	}
-
-	return lastErr
-}
-
 // ConfigurePodRouter configures the pod router with proper networking settings
 func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, poolName string) error {
 	config := RouterConfig{
@@ -99,7 +72,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
 	}
 
-	// Configure depending on router type
+	// Clone depending on router type
 	switch routerType {
 	case "pfsense":
 		// Configure router WAN IP to have correct third octet using qemu agent API call
@@ -116,7 +89,8 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			RequestBody: reqBody,
 		}
 
-		if err := s.agentExecWithRetry(execReq); err != nil {
+		_, err := s.RequestHelper.MakeRequest(execReq)
+		if err != nil {
 			return fmt.Errorf("failed to make IP change request: %v", err)
 		}
 
@@ -134,7 +108,8 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			RequestBody: vipReqBody,
 		}
 
-		if err := s.agentExecWithRetry(vipExecReq); err != nil {
+		_, err = s.RequestHelper.MakeRequest(vipExecReq)
+		if err != nil {
 			return fmt.Errorf("failed to make VIP change request: %v", err)
 		}
 	case "vyos":
@@ -153,7 +128,8 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			RequestBody: reqBody,
 		}
 
-		if err := s.agentExecWithRetry(execReq); err != nil {
+		_, err := s.RequestHelper.MakeRequest(execReq)
+		if err != nil {
 			return fmt.Errorf("failed to run VyOS setup script: %v", err)
 		}
 

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -172,6 +172,12 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			return fmt.Errorf("failed to make VIP change request: %v", err)
 		}
 	case "vyos":
+		// Wait for /config to be mounted before modifying the script
+		waitCmd := fmt.Sprintf("for i in $(seq 1 30); do [ -f %s ] && exit 0; sleep 2; done; exit 1", config.VYOSScriptPath)
+		if err := s.execAgentCommand(node, vmid, []string{"sh", "-c", waitCmd}); err != nil {
+			return fmt.Errorf("timed out waiting for %s to be available: %v", config.VYOSScriptPath, err)
+		}
+
 		err := s.execAgentCommand(node, vmid, []string{
 			"sh",
 			"-c",

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -40,7 +40,7 @@ func (s *ProxmoxService) GetRouterType(router VM) (string, error) {
 }
 
 // ConfigurePodRouter configures the pod router with proper networking settings
-func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string) error {
+func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, hostname string) error {
 	config := RouterConfig{
 		WANScriptPath:  s.Config.WANScriptPath,
 		VIPScriptPath:  s.Config.VIPScriptPath,
@@ -117,7 +117,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			"command": []string{
 				"sh",
 				"-c",
-				fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g' %s", podNumber, config.WANIPBase, config.VYOSScriptPath),
+				fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g;s/{{HOSTNAME}}/%s/g' %s", podNumber, config.WANIPBase, hostname, config.VYOSScriptPath),
 			},
 		}
 

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -39,6 +39,33 @@ func (s *ProxmoxService) GetRouterType(router VM) (string, error) {
 	}
 }
 
+// agentExecWithRetry retries an agent/exec request with exponential backoff.
+// The QEMU guest agent may respond to pings before it's fully ready to handle
+// exec commands (Proxmox returns status 596 in that case).
+func (s *ProxmoxService) agentExecWithRetry(execReq tools.ProxmoxAPIRequest) error {
+	backoff := 2 * time.Second
+	maxBackoff := 15 * time.Second
+	maxRetries := 10
+
+	var lastErr error
+	for attempt := range maxRetries {
+		_, lastErr = s.RequestHelper.MakeRequest(execReq)
+		if lastErr == nil {
+			return nil
+		}
+
+		if !strings.Contains(lastErr.Error(), "status 596") {
+			return lastErr // Non-retryable error
+		}
+
+		log.Printf("agent/exec attempt %d/%d failed with status 596, retrying in %v", attempt+1, maxRetries, backoff)
+		time.Sleep(backoff)
+		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
+	}
+
+	return lastErr
+}
+
 // ConfigurePodRouter configures the pod router with proper networking settings
 func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, poolName string) error {
 	config := RouterConfig{
@@ -72,7 +99,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
 	}
 
-	// Clone depending on router type
+	// Configure depending on router type
 	switch routerType {
 	case "pfsense":
 		// Configure router WAN IP to have correct third octet using qemu agent API call
@@ -89,8 +116,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			RequestBody: reqBody,
 		}
 
-		_, err := s.RequestHelper.MakeRequest(execReq)
-		if err != nil {
+		if err := s.agentExecWithRetry(execReq); err != nil {
 			return fmt.Errorf("failed to make IP change request: %v", err)
 		}
 
@@ -108,8 +134,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			RequestBody: vipReqBody,
 		}
 
-		_, err = s.RequestHelper.MakeRequest(vipExecReq)
-		if err != nil {
+		if err := s.agentExecWithRetry(vipExecReq); err != nil {
 			return fmt.Errorf("failed to make VIP change request: %v", err)
 		}
 	case "vyos":
@@ -128,8 +153,7 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 			RequestBody: reqBody,
 		}
 
-		_, err := s.RequestHelper.MakeRequest(execReq)
-		if err != nil {
+		if err := s.agentExecWithRetry(execReq); err != nil {
 			return fmt.Errorf("failed to run VyOS setup script: %v", err)
 		}
 

--- a/internal/proxmox/networking.go
+++ b/internal/proxmox/networking.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"math"
@@ -9,6 +10,84 @@ import (
 
 	"github.com/cpp-cyber/proclone/internal/tools"
 )
+
+// agentExecResult holds the response from agent/exec
+type agentExecResult struct {
+	PID int `json:"pid"`
+}
+
+// agentExecStatus holds the response from agent/exec-status
+type agentExecStatus struct {
+	Exited   bool   `json:"exited"`
+	ExitCode int    `json:"exitcode"`
+	OutData  string `json:"out-data"`
+	ErrData  string `json:"err-data"`
+}
+
+// execAgentCommand runs a command via the QEMU guest agent and waits for it to complete,
+// returning an error if the command fails.
+func (s *ProxmoxService) execAgentCommand(node string, vmid int, command []string) error {
+	reqBody := map[string]any{
+		"command": command,
+	}
+
+	execReq := tools.ProxmoxAPIRequest{
+		Method:      "POST",
+		Endpoint:    fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec", node, vmid),
+		RequestBody: reqBody,
+	}
+
+	rsp, err := s.RequestHelper.MakeRequest(execReq)
+	if err != nil {
+		return fmt.Errorf("agent exec request failed: %v", err)
+	}
+
+	var result agentExecResult
+	if err := json.Unmarshal(rsp, &result); err != nil {
+		return fmt.Errorf("failed to parse agent exec response: %v", err)
+	}
+
+	log.Printf("Agent exec started on VM %d with PID %d: %v", vmid, result.PID, command)
+
+	// Poll exec-status until the command finishes
+	statusReq := tools.ProxmoxAPIRequest{
+		Method:   "GET",
+		Endpoint: fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec-status?pid=%d", node, vmid, result.PID),
+	}
+
+	timeout := 60 * time.Second
+	startTime := time.Now()
+	for {
+		if time.Since(startTime) > timeout {
+			return fmt.Errorf("agent exec timed out waiting for PID %d on VM %d", result.PID, vmid)
+		}
+
+		statusRsp, err := s.RequestHelper.MakeRequest(statusReq)
+		if err != nil {
+			// exec-status returns 500 while the command is still running
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		var status agentExecStatus
+		if err := json.Unmarshal(statusRsp, &status); err != nil {
+			return fmt.Errorf("failed to parse agent exec-status response: %v", err)
+		}
+
+		if !status.Exited {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		if status.ExitCode != 0 {
+			return fmt.Errorf("agent exec on VM %d exited with code %d, stderr: %s, stdout: %s",
+				vmid, status.ExitCode, status.ErrData, status.OutData)
+		}
+
+		log.Printf("Agent exec on VM %d PID %d completed successfully", vmid, result.PID)
+		return nil
+	}
+}
 
 // RouterConfig holds configuration needed for router operations
 type RouterConfig struct {
@@ -72,62 +151,32 @@ func (s *ProxmoxService) ConfigurePodRouter(podNumber int, node string, vmid int
 		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
 	}
 
-	// Clone depending on router type
+	// Configure depending on router type
 	switch routerType {
 	case "pfsense":
 		// Configure router WAN IP to have correct third octet using qemu agent API call
-		reqBody := map[string]any{
-			"command": []string{
-				config.WANScriptPath,
-				fmt.Sprintf("%s%d.1", config.WANIPBase, podNumber),
-			},
-		}
-
-		execReq := tools.ProxmoxAPIRequest{
-			Method:      "POST",
-			Endpoint:    fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec", node, vmid),
-			RequestBody: reqBody,
-		}
-
-		_, err := s.RequestHelper.MakeRequest(execReq)
+		err := s.execAgentCommand(node, vmid, []string{
+			config.WANScriptPath,
+			fmt.Sprintf("%s%d.1", config.WANIPBase, podNumber),
+		})
 		if err != nil {
 			return fmt.Errorf("failed to make IP change request: %v", err)
 		}
 
-		// Send agent exec request to change VIP subnet
-		vipReqBody := map[string]any{
-			"command": []string{
-				config.VIPScriptPath,
-				fmt.Sprintf("%s%d.0", config.WANIPBase, podNumber),
-			},
-		}
-
-		vipExecReq := tools.ProxmoxAPIRequest{
-			Method:      "POST",
-			Endpoint:    fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec", node, vmid),
-			RequestBody: vipReqBody,
-		}
-
-		_, err = s.RequestHelper.MakeRequest(vipExecReq)
+		// Change VIP subnet
+		err = s.execAgentCommand(node, vmid, []string{
+			config.VIPScriptPath,
+			fmt.Sprintf("%s%d.0", config.WANIPBase, podNumber),
+		})
 		if err != nil {
 			return fmt.Errorf("failed to make VIP change request: %v", err)
 		}
 	case "vyos":
-		reqBody := map[string]any{
-			"command": []string{
-				"sh",
-				"-c",
-				fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g;s/{{HOSTNAME}}/%s/g' %s", podNumber, config.WANIPBase, hostname, config.VYOSScriptPath),
-			},
-		}
-
-		execReq := tools.ProxmoxAPIRequest{
-			Method:      "POST",
-			Endpoint:    fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec", node, vmid),
-			RequestBody: reqBody,
-		}
-
-		_, err := s.RequestHelper.MakeRequest(execReq)
+		err := s.execAgentCommand(node, vmid, []string{
+			"sh",
+			"-c",
+			fmt.Sprintf("sed -i -e 's/{{THIRD_OCTET}}/%d/g;s/{{NETWORK_PREFIX}}/%s/g;s/{{HOSTNAME}}/%s/g' %s", podNumber, config.WANIPBase, hostname, config.VYOSScriptPath),
+		})
 		if err != nil {
 			return fmt.Errorf("failed to make IP change request: %v", err)
 		}

--- a/internal/proxmox/pools.go
+++ b/internal/proxmox/pools.go
@@ -320,7 +320,7 @@ func (s *ProxmoxService) CreateTemplatePool(creator string, name string, addRout
 		// Remove the first VMID from the list
 		vmIDs = vmIDs[1:]
 
-		upid, err := s.cloneVMWithUPID(routerCloneReq)
+		upid, err := s.CloneVMWithUPID(routerCloneReq)
 		if err != nil {
 			return err
 		}
@@ -337,7 +337,7 @@ func (s *ProxmoxService) CreateTemplatePool(creator string, name string, addRout
 			TargetNode: bestNode,
 		}
 
-		upid, err := s.cloneVMWithUPID(vmCloneReq)
+		upid, err := s.CloneVMWithUPID(vmCloneReq)
 		if err != nil {
 			return err
 		}

--- a/internal/proxmox/pools.go
+++ b/internal/proxmox/pools.go
@@ -446,7 +446,7 @@ func (s *ProxmoxService) CreateTemplatePool(creator string, name string, addRout
 	log.Printf("Third octect is %d", octect)
 
 	log.Printf("Configuring router")
-	err = s.ConfigurePodRouter(octect, bestNode, routerVMID, routerType, poolName)
+	err = s.ConfigurePodRouter(octect, bestNode, routerVMID, routerType)
 	if err != nil {
 		return fmt.Errorf("failed to configure router for %s: %v", routerType, err)
 	}

--- a/internal/proxmox/pools.go
+++ b/internal/proxmox/pools.go
@@ -446,7 +446,7 @@ func (s *ProxmoxService) CreateTemplatePool(creator string, name string, addRout
 	log.Printf("Third octect is %d", octect)
 
 	log.Printf("Configuring router")
-	err = s.ConfigurePodRouter(octect, bestNode, routerVMID, routerType)
+	err = s.ConfigurePodRouter(octect, bestNode, routerVMID, routerType, poolName)
 	if err != nil {
 		return fmt.Errorf("failed to configure router for %s: %v", routerType, err)
 	}

--- a/internal/proxmox/tasks.go
+++ b/internal/proxmox/tasks.go
@@ -38,9 +38,10 @@ func (s *ProxmoxService) stopTask(node string, upid string) error {
 		Endpoint: fmt.Sprintf("/nodes/%s/tasks/%s", node, upid),
 	}
 
-	var nilResponse string
-	if err := s.RequestHelper.MakeRequestAndUnmarshal(taskReq, &nilResponse); err != nil {
+	_, err := s.RequestHelper.MakeRequest(taskReq)
+	if err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/internal/proxmox/tasks.go
+++ b/internal/proxmox/tasks.go
@@ -18,3 +18,29 @@ func (s *ProxmoxService) getActiveCloningTasks(node string) ([]Task, error) {
 	}
 	return activeCloningTasks, nil
 }
+
+func (s *ProxmoxService) getTaskFromUPID(node string, upid string) (Task, error) {
+	taskReq := tools.ProxmoxAPIRequest{
+		Method:   "GET",
+		Endpoint: fmt.Sprintf("/nodes/%s/tasks/%s/status", node, upid),
+	}
+
+	var taskStatus Task
+	if err := s.RequestHelper.MakeRequestAndUnmarshal(taskReq, &taskStatus); err != nil {
+		return nil, err
+	}
+	return taskStatus, nil
+}
+
+func (s *ProxmoxService) stopTask(node string, upid string) error {
+	taskReq := tools.ProxmoxAPIRequest{
+		Method:   "DELETE",
+		Endpoint: fmt.Sprintf("/nodes/%s/tasks/%s", node, upid),
+	}
+
+	var nilResponse string
+	if err := s.RequestHelper.MakeRequestAndUnmarshal(taskReq, &nilResponse); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/proxmox/tasks.go
+++ b/internal/proxmox/tasks.go
@@ -19,7 +19,7 @@ func (s *ProxmoxService) getActiveCloningTasks(node string) ([]Task, error) {
 	return activeCloningTasks, nil
 }
 
-func (s *ProxmoxService) getTaskFromUPID(node string, upid string) (Task, error) {
+func (s *ProxmoxService) getTaskFromUPID(node string, upid string) (*Task, error) {
 	taskReq := tools.ProxmoxAPIRequest{
 		Method:   "GET",
 		Endpoint: fmt.Sprintf("/nodes/%s/tasks/%s/status", node, upid),
@@ -29,7 +29,7 @@ func (s *ProxmoxService) getTaskFromUPID(node string, upid string) (Task, error)
 	if err := s.RequestHelper.MakeRequestAndUnmarshal(taskReq, &taskStatus); err != nil {
 		return nil, err
 	}
-	return taskStatus, nil
+	return &taskStatus, nil
 }
 
 func (s *ProxmoxService) stopTask(node string, upid string) error {

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -205,7 +205,7 @@ type Task struct {
 	ExitStatus string `json:"exitstatus"`
 }
 
-type cloningTask struct {
+type CloningTask struct {
 	UPID     string `json:"upid"`
 	Node     string `json:"node"`
 }

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -60,6 +60,7 @@ type Service interface {
 	CloneVM(req VMCloneRequest) error
 	WaitForDisk(node string, vmID int, maxWait time.Duration) error
 	WaitForLock(node string, vmID int) error
+	WaitForCloneTask(node string, upid string) error
 	WaitForRunning(node string, vmID int) error
 	WaitForStopped(node string, vmID int) error
 
@@ -202,4 +203,9 @@ type Task struct {
 	EndTime    int64  `json:"endtime"`
 	Status     string `json:"status"`
 	ExitStatus string `json:"exitstatus"`
+}
+
+type cloningTask struct {
+	UPID     string `json:"upid"`
+	Node     string `json:"node"`
 }

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -58,6 +58,7 @@ type Service interface {
 	DeleteVMSnapshot(node string, vmID int, snapshotName string) error
 	ConvertVMToTemplate(node string, vmID int) error
 	CloneVM(req VMCloneRequest) error
+	CloneVMWithUPID(req VMCloneRequest) (string, error)
 	WaitForDisk(node string, vmID int, maxWait time.Duration) error
 	WaitForLock(node string, vmID int) error
 	WaitForCloneTask(node string, upid string) error

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -76,7 +76,7 @@ type Service interface {
 
 	// Networking
 	GetRouterType(router VM) (string, error)
-	ConfigurePodRouter(podNumber int, node string, vmid int, routerType string) error
+	ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, hostname string) error
 	SetPodVnet(poolName string, vnetName string, routerVMID int) error
 	GetUsedVNets() ([]VNet, error)
 	CreateTemplatePool(creator string, name string, addRouter bool, vms []VM) error

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -26,7 +26,7 @@ type ProxmoxConfig struct {
 	RouterWaitTimeout time.Duration `envconfig:"ROUTER_WAIT_TIMEOUT" default:"120s"`
 	WANScriptPath     string        `envconfig:"WAN_SCRIPT_PATH" default:"/home/update-wan-ip.sh"`
 	VIPScriptPath     string        `envconfig:"VIP_SCRIPT_PATH" default:"/home/update-wan-vip.sh"`
-	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/vyos-postconfig-bootup.script"`
+	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/setup.sh"`
 	WANIPBase         string        `envconfig:"WAN_IP_BASE" default:"172.16."`
 	Nodes             []string      // Parsed from NodesStr
 	APIToken          string        // Computed from TokenID and TokenSecret

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -26,7 +26,7 @@ type ProxmoxConfig struct {
 	RouterWaitTimeout time.Duration `envconfig:"ROUTER_WAIT_TIMEOUT" default:"120s"`
 	WANScriptPath     string        `envconfig:"WAN_SCRIPT_PATH" default:"/home/update-wan-ip.sh"`
 	VIPScriptPath     string        `envconfig:"VIP_SCRIPT_PATH" default:"/home/update-wan-vip.sh"`
-	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/setup.sh"`
+	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/vyos-postconfig-bootup.script"`
 	WANIPBase         string        `envconfig:"WAN_IP_BASE" default:"172.16."`
 	Nodes             []string      // Parsed from NodesStr
 	APIToken          string        // Computed from TokenID and TokenSecret
@@ -76,7 +76,7 @@ type Service interface {
 
 	// Networking
 	GetRouterType(router VM) (string, error)
-	ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, poolName string) error
+	ConfigurePodRouter(podNumber int, node string, vmid int, routerType string) error
 	SetPodVnet(poolName string, vnetName string, routerVMID int) error
 	GetUsedVNets() ([]VNet, error)
 	CreateTemplatePool(creator string, name string, addRouter bool, vms []VM) error

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -26,7 +26,7 @@ type ProxmoxConfig struct {
 	RouterWaitTimeout time.Duration `envconfig:"ROUTER_WAIT_TIMEOUT" default:"120s"`
 	WANScriptPath     string        `envconfig:"WAN_SCRIPT_PATH" default:"/home/update-wan-ip.sh"`
 	VIPScriptPath     string        `envconfig:"VIP_SCRIPT_PATH" default:"/home/update-wan-vip.sh"`
-	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/vyos-postconfig-bootup.script"`
+	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/setup.sh"`
 	WANIPBase         string        `envconfig:"WAN_IP_BASE" default:"172.16."`
 	Nodes             []string      // Parsed from NodesStr
 	APIToken          string        // Computed from TokenID and TokenSecret
@@ -76,7 +76,7 @@ type Service interface {
 
 	// Networking
 	GetRouterType(router VM) (string, error)
-	ConfigurePodRouter(podNumber int, node string, vmid int, routerType string) error
+	ConfigurePodRouter(podNumber int, node string, vmid int, routerType string, poolName string) error
 	SetPodVnet(poolName string, vnetName string, routerVMID int) error
 	GetUsedVNets() ([]VNet, error)
 	CreateTemplatePool(creator string, name string, addRouter bool, vms []VM) error

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -26,7 +26,7 @@ type ProxmoxConfig struct {
 	RouterWaitTimeout time.Duration `envconfig:"ROUTER_WAIT_TIMEOUT" default:"120s"`
 	WANScriptPath     string        `envconfig:"WAN_SCRIPT_PATH" default:"/home/update-wan-ip.sh"`
 	VIPScriptPath     string        `envconfig:"VIP_SCRIPT_PATH" default:"/home/update-wan-vip.sh"`
-	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/setup.sh"`
+	VYOSScriptPath    string        `envconfig:"VYOS_SCRIPT_PATH" default:"/config/scripts/vyos-postconfig-bootup.script"`
 	WANIPBase         string        `envconfig:"WAN_IP_BASE" default:"172.16."`
 	Nodes             []string      // Parsed from NodesStr
 	APIToken          string        // Computed from TokenID and TokenSecret

--- a/internal/proxmox/vms.go
+++ b/internal/proxmox/vms.go
@@ -284,6 +284,33 @@ func (s *ProxmoxService) WaitForLock(node string, vmID int) error {
 	return fmt.Errorf("timeout waiting for VM lock to be cleared")
 }
 
+func (s *ProxmoxService) WaitForCloneTask(node string, upid string) error {
+	timeout := 1 * time.Minute
+	start := time.Now()
+
+	for time.Since(start) < timeout {
+		task, err := s.getTaskFromUPID(node, upid)
+		if err != nil {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		log.Printf("Clone task %s status: '%s'", upid, task.Status)
+
+		if task.Status == "stopped" {
+			return nil // Task finished
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	if err := s.stopTask(node, upid); err != nil {
+		return fmt.Errorf("failed to stop task after timeout, continuing anyway")
+	}
+
+	return fmt.Errorf("timeout waiting for cloning task to be stopped")
+}
+
 // =================================================
 // Private Functions
 // =================================================

--- a/internal/proxmox/vms.go
+++ b/internal/proxmox/vms.go
@@ -144,7 +144,7 @@ func (s *ProxmoxService) CloneVM(req VMCloneRequest) error {
 	return nil
 }
 
-func (s *ProxmoxService) cloneVMWithUPID(req VMCloneRequest) (string, error) {
+func (s *ProxmoxService) CloneVMWithUPID(req VMCloneRequest) (string, error) {
 	// Clone VM
 	cloneBody := map[string]any{
 		"newid":  req.NewVMID,


### PR DESCRIPTION
Improved the Router Setup Script
 - Added support for passing PoolID-PoolName as `hostname` for the router for SOC Logging
 - Improved retry logic for QEMU guest agent to run said setup script.

Kayhon: Tracking clone process via UPID.