### PR TITLE
Pool names start with a letter

### DIFF
--- a/internal/cloning/cloning_service.go
+++ b/internal/cloning/cloning_service.go
@@ -146,7 +146,7 @@ func (cs *CloningService) CloneTemplate(req CloneRequest) error {
 	}
 
 	for i := range req.Targets {
-		req.Targets[i].PoolName = fmt.Sprintf("%s_%s_%s", podIDs[i], req.Template, req.Targets[i].Name)
+		req.Targets[i].PoolName = fmt.Sprintf("pod_%s_%s_%s", podIDs[i], req.Template, req.Targets[i].Name)
 		req.Targets[i].PodID = podIDs[i]
 		req.Targets[i].PodNumber = podNumbers[i]
 		req.Targets[i].VMIDs = vmIDs[i*(numVMsPerTarget) : (i+1)*(numVMsPerTarget)]

--- a/internal/proxmox/pools.go
+++ b/internal/proxmox/pools.go
@@ -16,7 +16,7 @@ import (
 func (s *ProxmoxService) GetPoolVMs(poolName string) ([]VirtualResource, error) {
 	req := tools.ProxmoxAPIRequest{
 		Method:   "GET",
-		Endpoint: fmt.Sprintf("/pools/?poolid=%s", poolName),
+		Endpoint: fmt.Sprintf("/pools/%s", poolName),
 	}
 
 	var poolResponse struct {
@@ -92,7 +92,7 @@ func (s *ProxmoxService) SetPoolPermission(poolName string, targetName string, i
 func (s *ProxmoxService) DeletePool(poolName string) error {
 	req := tools.ProxmoxAPIRequest{
 		Method:   "DELETE",
-		Endpoint: fmt.Sprintf("/pools/?poolid=%s", poolName),
+		Endpoint: fmt.Sprintf("/pools/%s", poolName),
 	}
 
 	_, err := s.RequestHelper.MakeRequest(req)

--- a/internal/proxmox/pools.go
+++ b/internal/proxmox/pools.go
@@ -16,7 +16,7 @@ import (
 func (s *ProxmoxService) GetPoolVMs(poolName string) ([]VirtualResource, error) {
 	req := tools.ProxmoxAPIRequest{
 		Method:   "GET",
-		Endpoint: fmt.Sprintf("/pools/%s", poolName),
+		Endpoint: fmt.Sprintf("/pools/?poolid=%s", poolName),
 	}
 
 	var poolResponse struct {
@@ -92,7 +92,7 @@ func (s *ProxmoxService) SetPoolPermission(poolName string, targetName string, i
 func (s *ProxmoxService) DeletePool(poolName string) error {
 	req := tools.ProxmoxAPIRequest{
 		Method:   "DELETE",
-		Endpoint: fmt.Sprintf("/pools/%s", poolName),
+		Endpoint: fmt.Sprintf("/pools/?poolid=%s", poolName),
 	}
 
 	_, err := s.RequestHelper.MakeRequest(req)


### PR DESCRIPTION
Pool names must start with a letter in proxmox 9.